### PR TITLE
Feat: 메인 화면, 스테이지 선택 화면 라우팅 구현

### DIFF
--- a/app/GameScreen/GameScreen.jsx
+++ b/app/GameScreen/GameScreen.jsx
@@ -1,0 +1,5 @@
+import { View } from "react-native";
+
+export default function GameScreen() {
+  return <View />;
+}

--- a/app/MainScreen/MainScreen.jsx
+++ b/app/MainScreen/MainScreen.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { router } from "expo-router";
 import { View, Image, TouchableOpacity, StyleSheet } from "react-native";
 import { vw, vh } from "react-native-expo-viewport-units";
 
@@ -27,14 +28,18 @@ function BallCustomization() {
 }
 
 export default function MainScreen() {
-  const [isModalVisible, setIsModalVisible] = useState(false);
+  const [isExitGameModalVisible, setIsExitGameModalVisible] = useState(false);
 
   function handleOpenModal() {
-    setIsModalVisible(true);
+    setIsExitGameModalVisible(true);
   }
 
   function handleCloseModal() {
-    setIsModalVisible(false);
+    setIsExitGameModalVisible(false);
+  }
+
+  function handleStartButtonTouch() {
+    router.replace("/StageSelectScreen/StageSelectScreen");
   }
 
   return (
@@ -47,6 +52,7 @@ export default function MainScreen() {
             containerStyle={[styles.button, styles.brightGreen]}
             textStyle={styles.text}
             buttonText="게임 시작"
+            onPress={handleStartButtonTouch}
           />
           <CustomButton
             containerStyle={[styles.button, styles.black]}
@@ -57,8 +63,9 @@ export default function MainScreen() {
         </View>
       </View>
       <ConfirmationModal
-        visible={isModalVisible}
-        onRequestModalClose={handleCloseModal}
+        visible={isExitGameModalVisible}
+        onleftButtonTouch={null}
+        onRightButtonTouch={handleCloseModal}
         modalMessage="게임을 종료하시겠습니까?"
       />
     </>

--- a/app/StageSelectScreen/StageSelectScreen.jsx
+++ b/app/StageSelectScreen/StageSelectScreen.jsx
@@ -1,4 +1,5 @@
 import { View, Text, Image, TouchableOpacity, StyleSheet } from "react-native";
+import { router } from "expo-router";
 import { vw, vh } from "react-native-expo-viewport-units";
 
 import CustomButton from "../../src/components/CustomButton/CustomButton";
@@ -15,10 +16,11 @@ function StageCardButton({
   sterOneImage,
   starTwoImage,
   starThreeImage,
+  onStageCardPress,
 }) {
   return (
-    <TouchableOpacity style={cardButtonStyle} disabled={cardDisabled}>
-      <Text style={[!cardDisabled ? styles.enableCardText : styles.disableCardText]}>
+    <TouchableOpacity style={cardButtonStyle} disabled={cardDisabled} onPress={onStageCardPress}>
+      <Text style={!cardDisabled ? styles.enableCardText : styles.disableCardText}>
         {stageLevel}
       </Text>
       {!cardDisabled && (
@@ -33,6 +35,14 @@ function StageCardButton({
 }
 
 export default function StageSelectScreen() {
+  function handleStageCardButtonTouch() {
+    router.replace("/GameScreen/GameScreen");
+  }
+
+  function handleMainButtonTouch() {
+    router.replace("/MainScreen/MainScreen");
+  }
+
   return (
     <View style={[sharedStyles.container, sharedStyles.centerHorizontal, styles.containerPadding]}>
       <Text style={sharedStyles.title}>STAGE</Text>
@@ -44,6 +54,7 @@ export default function StageSelectScreen() {
           sterOneImage={filledStar}
           starTwoImage={filledStar}
           starThreeImage={filledStar}
+          onStageCardPress={handleStageCardButtonTouch}
         />
         <StageCardButton
           cardDisabled={false}
@@ -52,18 +63,20 @@ export default function StageSelectScreen() {
           sterOneImage={emptyStar}
           starTwoImage={emptyStar}
           starThreeImage={emptyStar}
+          onStageCardPress={handleStageCardButtonTouch}
         />
         <StageCardButton
-          cardDisabled={true}
+          cardDisabled
           cardButtonStyle={styles.disableCardButton}
           stageLevel="Stage 3"
+          onStageCardPress={handleStageCardButtonTouch}
         />
       </View>
       <CustomButton
         buttonText="메인"
         containerStyle={styles.buttonContainer}
         textStyle={styles.buttonText}
-        onPress={null}
+        onPress={handleMainButtonTouch}
       />
     </View>
   );

--- a/app/index.js
+++ b/app/index.js
@@ -1,3 +1,3 @@
-import Game3DView from "./Game3DView/Game3DView";
+import MainScreen from "./MainScreen/MainScreen";
 
-export default Game3DView;
+export default MainScreen;

--- a/src/components/ConfirmationModal/ConfirmationModal.jsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.jsx
@@ -3,15 +3,28 @@ import { vw, vh } from "react-native-expo-viewport-units";
 import CustomButton from "../CustomButton/CustomButton";
 import sharedStyles from "../../styles/sharedStyles";
 
-export default function ConfirmationModal({ visible, onRequestModalClose, modalMessage }) {
+export default function ConfirmationModal({
+  visible,
+  modalMessage,
+  onleftButtonTouch,
+  onRightButtonTouch,
+}) {
   return (
-    <Modal visible={visible} transparent animationType="fade" onRequestClose={onRequestModalClose}>
+    <Modal visible={visible} transparent animationType="fade">
       <View style={styles.modalBackGround}>
         <View style={styles.modalView}>
           <Text style={styles.messageText}>{modalMessage}</Text>
           <View style={sharedStyles.rowWrapper}>
-            <CustomButton containerStyle={styles.buttonContainer} buttonText="YES" />
-            <CustomButton containerStyle={styles.buttonContainer} buttonText="NO" />
+            <CustomButton
+              containerStyle={styles.buttonContainer}
+              buttonText="YES"
+              onPress={onleftButtonTouch}
+            />
+            <CustomButton
+              containerStyle={styles.buttonContainer}
+              buttonText="NO"
+              onPress={onRightButtonTouch}
+            />
           </View>
         </View>
       </View>


### PR DESCRIPTION
## Task Kanban
[메인, 스테이지 선택 화면 라우팅](https://marsh-planarian-d5e.notion.site/8bd71afb801945b5a3918f6265ceb483?pvs=4)

## Description
- 메인 화면과 스테이지 선택 화면 간 라우팅을 구현하였습니다.
- 메인 화면의 게임 시작 버튼, 스테이지 선택 화면의 메인 버튼을 통해 각 화면 간 이동이 가능합니다.
- 스테이지 선택 화면의 스테이지 카드 버튼을 클릭하면 게임 화면으로 이동합니다.
- 현재 게임 화면은 구현되어있지 않아, 흰 화면만 나타나는 상태입니다.
- 또한, 메인 화면의 게임 종료 버튼 터치 시 나타나는 모달의 기능을 구현하였습니다.
  - 게임 종료 안내 모달에서 NO 버튼을 클릭하면 모달이 사라집니다.

## 특이사항
- 앱 종료에 대해 알아보았습니다. 기능의 중요도에 비해 복잡도가 상당한 기능이라 생각되는데요, 어떤 식으로 구현해야할지 상의가 필요해보입니다.
  - 앱 종료는 안드로이드, 아이폰에서 각각 다르게 구현해야 합니다. (구현해야하는 방식이 다릅니다)
  - 안드로이드에서는 BackHandler API를 사용해 구현이 가능합니다. 단, 이는 앱의 완전 종료가 아닌 디바이스의 백그라운드로 앱을 내보내는 방식으로 작동합니다.
    - [BackHandler](https://reactnative.dev/docs/backhandler)
  - (Android, ios공통) ReactNative에서는 앱을 완전히 종료하는 기능을 지원하지 않습니다. 라이브러리의 사용이 필요할 수 있습니다. 라이브러리를 사용해도 Java와 같은 네이티브 코드 작성이 필요하다고 합니다.
  - [react-native-exit-app 라이브러리](https://github.com/wumke/react-native-exit-app)
  - [npm: react-native-exit-app 라이브러리](https://www.npmjs.com/package/react-native-exit-app)
## PR 전 체크리스트
- [x] 최신 브랜치를 pull하였습니다.
- [x] 리뷰어를 설정했습니다.
- [x] base 브랜치를 확인하였습니다.
- [x] 브랜치명을 확인했습니다.
- [x] 팀원이 쉽게 이해할 수 있도록, 구현 사항에 대해 설명하고 참고 자료를 제공했습니다. 