### PR TITLE
Feat: 공의 이동 및 회전과 트리거 오브젝트 이동 구현

### DIFF
--- a/app/Game3DScene/Game3DScene.jsx
+++ b/app/Game3DScene/Game3DScene.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, useMemo } from "react";
+import { useEffect, useRef, useState, useMemo } from "react";
 import { View, StyleSheet, Platform } from "react-native";
 import { Canvas } from "@react-three/fiber";
 import { Accelerometer } from "expo-sensors";
@@ -38,14 +38,16 @@ function StageOneLand() {
 
 export default function Game3DScreen() {
   const ballMeshRef = useRef();
-  const [patternIndex, setPatternIndex] = useState(0);
-  const patterns = useMemo(() => [patternTexture, patternTextureSecond, patternTextureThird]);
-  const selectedPattern = patterns[patternIndex];
+
   const [accelData, setAccelData] = useState({ x: 0, y: 0, z: 0 });
   const initialTilt = useRef({ x: 0, y: 0, z: 0 });
   const position = useRef({ x: 0, y: 1, z: 0 });
   const velocity = useRef({ x: 0, y: 0, z: 0 });
   const friction = 1.2;
+
+  const [patternIndex, setPatternIndex] = useState(0);
+  const patterns = useMemo(() => [patternTexture, patternTextureSecond, patternTextureThird]);
+  const selectedPattern = patterns[patternIndex];
 
   function normalizeSensorData(data) {
     if (Platform.OS === "android") {

--- a/app/LoadingScreen/LoadingScreen.jsx
+++ b/app/LoadingScreen/LoadingScreen.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { View, Image, Text, StyleSheet } from "react-native";
 import { vw, vh } from "react-native-expo-viewport-units";
 import { Canvas } from "@react-three/fiber";

--- a/app/LoadingScreen/LoadingScreen.jsx
+++ b/app/LoadingScreen/LoadingScreen.jsx
@@ -31,11 +31,13 @@ export default function LoadingScreen() {
       <Text style={styles.loadingText}>Loading...</Text>
       <Image style={styles.circleImage} source={circleImage} />
       <View style={styles.circleImage}>
-        <Canvas style={styles.canvasContainer}>
-          <ambientLight />
-          <directionalLight position={[10, 10, 10]} intensity={1} castShadow />
-          <Ball currentBallPatternTexture={selectedPattern} />
-        </Canvas>
+        <View style={styles.ballContainer}>
+          <Canvas style={styles.canvasContainer}>
+            <ambientLight />
+            <directionalLight position={[10, 10, 10]} intensity={1} castShadow />
+            <Ball currentBallPatternTexture={selectedPattern} />
+          </Canvas>
+        </View>
       </View>
     </View>
   );
@@ -50,6 +52,14 @@ const styles = StyleSheet.create({
     width: vw(50),
     height: vh(25),
     top: vh(-23.5),
+    position: "absolute",
+    resizeMode: "contain",
+    zIndex: 2,
+  },
+  ballContainer: {
+    width: vw(50),
+    height: vh(25),
+    top: vh(-4),
     position: "absolute",
     resizeMode: "contain",
     zIndex: 2,

--- a/src/components/Ball/Ball.jsx
+++ b/src/components/Ball/Ball.jsx
@@ -1,30 +1,70 @@
+import React, { useMemo, useRef } from "react";
 import { useFrame } from "@react-three/fiber";
-import { useMemo, useRef } from "react";
 import * as THREE from "three";
+import TransparentObject from "../TransparentObject/TransparentObject";
 
-export default function Ball({ currentBallPatternTexture }) {
-  const mesh = useRef();
+export default function Ball({
+  currentBallPatternTexture,
+  initialPosition,
+  initialVelocity,
+  accelData,
+  friction,
+  initialTilt,
+  ballMeshRef,
+  showTransparentObject = false,
+}) {
   const texture = useMemo(() => {
     const ballPatternTexture = new THREE.TextureLoader().load(currentBallPatternTexture);
     ballPatternTexture.wrapS = THREE.RepeatWrapping;
     ballPatternTexture.wrapT = THREE.RepeatWrapping;
     ballPatternTexture.repeat.set(3, 1);
-
     return ballPatternTexture;
   }, [currentBallPatternTexture]);
+  const accumulatedQuaternion = useRef(new THREE.Quaternion());
+  const position = useRef({ ...initialPosition });
+  const velocity = useRef({ ...initialVelocity });
 
-  useFrame(() => {
-    if (mesh.current) {
-      mesh.current.rotation.x -= 0.02;
-      mesh.current.rotation.y += 0.02;
-      mesh.current.rotation.z += 0.02;
+  useFrame((_, delta) => {
+    if (ballMeshRef?.current && position.current) {
+      const adjustedX = accelData.x - initialTilt.current.x;
+      const adjustedY = -(accelData.y - initialTilt.current.y);
+
+      velocity.current.x += adjustedX * delta * 20;
+      velocity.current.z += adjustedY * delta * 20;
+
+      velocity.current.x *= 1 - friction * delta;
+      velocity.current.z *= 1 - friction * delta;
+
+      position.current.x += velocity.current.x * delta * 3;
+      position.current.z += velocity.current.z * delta * 3;
+
+      const moveDirection = new THREE.Vector3(
+        velocity.current.x,
+        0,
+        velocity.current.z,
+      ).normalize();
+
+      const linearSpeed = Math.sqrt(velocity.current.x ** 2 + velocity.current.z ** 2);
+      const rotationSpeed = linearSpeed * delta;
+
+      const rotationAxis = new THREE.Vector3()
+        .crossVectors(new THREE.Vector3(0, 1, 0), moveDirection)
+        .normalize();
+
+      const quaternion = new THREE.Quaternion();
+      quaternion.setFromAxisAngle(rotationAxis, rotationSpeed);
+      accumulatedQuaternion.current.multiplyQuaternions(quaternion, accumulatedQuaternion.current);
+
+      ballMeshRef.current.quaternion.copy(accumulatedQuaternion.current);
+      ballMeshRef.current.position.set(position.current.x, position.current.y, position.current.z);
     }
   });
 
   return (
-    <mesh ref={mesh} position={[0, 1, 0]}>
-      <sphereGeometry args={[2, 42, 42]} />
+    <mesh ref={ballMeshRef}>
+      <sphereGeometry args={[2, 16, 16]} />
       <meshStandardMaterial map={texture} />
+      {showTransparentObject && <TransparentObject ballMeshRef={ballMeshRef} velocity={velocity} />}
     </mesh>
   );
 }

--- a/src/components/Ball/Ball.jsx
+++ b/src/components/Ball/Ball.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from "react";
+import { useMemo, useRef } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 import TransparentObject from "../TransparentObject/TransparentObject";
@@ -13,6 +13,10 @@ export default function Ball({
   ballMeshRef,
   showTransparentObject = false,
 }) {
+  const accumulatedQuaternion = useRef(new THREE.Quaternion());
+  const position = useRef({ ...initialPosition });
+  const velocity = useRef({ ...initialVelocity });
+
   const texture = useMemo(() => {
     const ballPatternTexture = new THREE.TextureLoader().load(currentBallPatternTexture);
     ballPatternTexture.wrapS = THREE.RepeatWrapping;
@@ -20,9 +24,6 @@ export default function Ball({
     ballPatternTexture.repeat.set(3, 1);
     return ballPatternTexture;
   }, [currentBallPatternTexture]);
-  const accumulatedQuaternion = useRef(new THREE.Quaternion());
-  const position = useRef({ ...initialPosition });
-  const velocity = useRef({ ...initialVelocity });
 
   useFrame((_, delta) => {
     if (ballMeshRef?.current && position.current) {

--- a/src/components/BallCustomization/BallCustomization.jsx
+++ b/src/components/BallCustomization/BallCustomization.jsx
@@ -35,11 +35,13 @@ export default function BallCustomization() {
       </TouchableOpacity>
       <View style={styles.circleContainer}>
         <Image style={styles.circleImage} source={circleImage} />
-        <Canvas style={styles.canvasContainer}>
-          <ambientLight />
-          <directionalLight position={[10, 10, 10]} intensity={1} castShadow />
-          <Ball currentBallPatternTexture={patterns[patternIndex]} />
-        </Canvas>
+        <View style={styles.ballContainer}>
+          <Canvas style={styles.canvasContainer}>
+            <ambientLight />
+            <directionalLight position={[10, 10, 10]} intensity={1} castShadow />
+            <Ball currentBallPatternTexture={patterns[patternIndex]} />
+          </Canvas>
+        </View>
       </View>
       <TouchableOpacity onPress={handleNextPattern}>
         <Image
@@ -63,6 +65,14 @@ const styles = StyleSheet.create({
     position: "relative",
     width: vw(50),
     height: vh(25),
+  },
+  ballContainer: {
+    width: vw(50),
+    height: vh(25),
+    top: vh(-4),
+    position: "absolute",
+    resizeMode: "contain",
+    zIndex: 2,
   },
   rowWrapper: {
     width: "80%",

--- a/src/components/CameraController/CameraController.jsx
+++ b/src/components/CameraController/CameraController.jsx
@@ -1,0 +1,22 @@
+import { useFrame, useThree } from "@react-three/fiber";
+import * as THREE from "three";
+
+export default function CameraController({ followTarget }) {
+  const { camera } = useThree();
+
+  useFrame(() => {
+    if (followTarget.current) {
+      const ballPosition = followTarget.current.position;
+      const desiredPosition = new THREE.Vector3(
+        ballPosition.x,
+        ballPosition.y + 15,
+        ballPosition.z + 30,
+      );
+
+      camera.position.lerp(desiredPosition, 0.1);
+      camera.lookAt(ballPosition);
+    }
+  });
+
+  return null;
+}

--- a/src/components/TransparentObject/TransparentObject.jsx
+++ b/src/components/TransparentObject/TransparentObject.jsx
@@ -1,0 +1,33 @@
+import { useRef } from "react";
+import * as THREE from "three";
+import { useFrame } from "@react-three/fiber";
+
+export default function TransparentObject({ ballMeshRef, velocity }) {
+  const transparentMeshRef = useRef();
+
+  useFrame(() => {
+    if (ballMeshRef?.current && transparentMeshRef.current) {
+      const ballPosition = ballMeshRef.current.position;
+      const moveDirection = new THREE.Vector3(
+        velocity.current.x,
+        0,
+        velocity.current.z,
+      ).normalize();
+
+      transparentMeshRef.current.position.set(
+        ballPosition.x - moveDirection.x,
+        ballPosition.y - 2,
+        ballPosition.z - moveDirection.z,
+      );
+
+      transparentMeshRef.current.rotation.set(0, 0, 0);
+    }
+  });
+
+  return (
+    <mesh ref={transparentMeshRef}>
+      <cylinderGeometry args={[2, 2, 0.3, 15]} />
+      <meshStandardMaterial color="#DAF7D9" />
+    </mesh>
+  );
+}


### PR DESCRIPTION
## Task Kanban
[공의 이동 및 회전과 트리거 오브젝트 이동 구현](https://www.notion.so/113109a84a434f86a43554e6c45d39c2?pvs=4)

## Description
- expo-sensors 라이브러리를 통해 가속도계 데이터를 불러왔습니다.
- 가속도계 데이터를 가공하여 이벤트 발생 시 가속도계의 값이 업데이트 되도록 구현했습니다.
- 게임 스테이지에 처음 접속했을 당시를 기준으로 기울기 0으로 세팅했습니다.
- 가속도계 데이터를 활용하여 공의 이동 속도가 디바이스 기울기에 비례하게 구현했습니다.
- 공의 회전 속도가 공의 이동 속도와 비례하게 구현했습니다.
- 트리거 오브젝트가 공이 이동함에 따라 함께 이동하게 구현했습니다.

## 특이사항
- 자이로 센서 데이터를 사용하여 테스트 했을 때 움직임이 부자연스러워 유저의 사용성이 떨어질 것을 고려하여, 가속도계 데이터만 이용하여 공의 이동 및 회전을 구현하였습니다.
- 트리거 오브젝트를 박스의 형태가 아닌 원의 형태로 공 아래에 배치하였고, 공의 움직임을 정확하게 따라가게 하여 테스트 과정을 거치며 수정 할 예정입니다.

## 스크린샷
<img src="https://github.com/RollingArt/rollingart-project/assets/166673478/511a7178-ba64-472d-9c6b-2f60a05f71dd" width="가로 사이즈">

## PR 전 체크리스트
- [x] 최신 브랜치를 pull하였습니다.
- [x] 리뷰어를 설정했습니다.
- [x] base 브랜치를 확인하였습니다.
- [x] 브랜치명을 확인했습니다.
- [x] 팀원이 쉽게 이해할 수 있도록, 구현 사항에 대해 설명하고 참고 자료를 제공했습니다. 