### PR TITLE
Feat: 메인 화면과 로딩 화면에서 사용하는 볼 컴포넌트 분리

### DIFF
--- a/app/Game3DScene/Game3DScene.jsx
+++ b/app/Game3DScene/Game3DScene.jsx
@@ -130,7 +130,6 @@ export default function Game3DScreen() {
         friction={friction}
         initialTilt={initialTilt}
         onPathUpdate={handlePathUpdate}
-        showTransparentObject={false}
       />
       <TransparentObject ballMeshRef={ballMeshRef} velocity={velocity} />
       <StageOneLand />

--- a/app/LoadingScreen/LoadingScreen.jsx
+++ b/app/LoadingScreen/LoadingScreen.jsx
@@ -4,7 +4,7 @@ import { vw, vh } from "react-native-expo-viewport-units";
 import { Canvas } from "@react-three/fiber";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
-import Ball from "../../src/components/Ball/Ball";
+import StaticBall from "../../src/components/StaticBall/StaticBall";
 
 import patternTexture from "../../assets/images/patternTexture.png";
 import patternTextureSecond from "../../assets/images/patternTextureSecond.png";
@@ -35,7 +35,7 @@ export default function LoadingScreen() {
           <Canvas style={styles.canvasContainer}>
             <ambientLight />
             <directionalLight position={[10, 10, 10]} intensity={1} castShadow />
-            <Ball currentBallPatternTexture={selectedPattern} />
+            <StaticBall currentBallPatternTexture={selectedPattern} />
           </Canvas>
         </View>
       </View>

--- a/src/components/Ball/Ball.jsx
+++ b/src/components/Ball/Ball.jsx
@@ -1,9 +1,7 @@
 import { useMemo, useRef } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
-import { useSharedValue, useAnimatedReaction, runOnJS } from "react-native-reanimated";
-
-import TransparentObject from "../TransparentObject/TransparentObject";
+import { useSharedValue, runOnJS } from "react-native-reanimated";
 
 export default function Ball({
   currentBallPatternTexture,
@@ -14,7 +12,6 @@ export default function Ball({
   initialTilt,
   ballMeshRef,
   onPathUpdate,
-  showTransparentObject = false,
 }) {
   const accumulatedQuaternion = useRef(new THREE.Quaternion());
   const position = useRef({ ...initialPosition });
@@ -112,30 +109,10 @@ export default function Ball({
     }
   });
 
-  useAnimatedReaction(
-    () => ({
-      x: positionX.value,
-      y: positionY.value,
-      z: positionZ.value,
-      rotationX: rotationX.value,
-      rotationZ: rotationZ.value,
-    }),
-    (values) => {
-      if (showTransparentObject) {
-        const mesh = ballMeshRef.current;
-        mesh.position.set(values.x, values.y, values.z);
-        mesh.rotation.x = values.rotationX;
-        mesh.rotation.z = values.rotationZ;
-      }
-    },
-    [ballMeshRef],
-  );
-
   return (
     <mesh ref={ballMeshRef}>
       <sphereGeometry args={[2, 16, 16]} />
       <meshStandardMaterial map={texture} />
-      {showTransparentObject && <TransparentObject ballMeshRef={ballMeshRef} velocity={velocity} />}
     </mesh>
   );
 }

--- a/src/components/BallCustomization/BallCustomization.jsx
+++ b/src/components/BallCustomization/BallCustomization.jsx
@@ -4,7 +4,7 @@ import { Canvas } from "@react-three/fiber";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { vw, vh } from "react-native-expo-viewport-units";
 
-import Ball from "../Ball/Ball";
+import StaticBall from "../StaticBall/StaticBall";
 
 import arrowButtonImage from "../../../assets/images/arrowButton.png";
 import circleImage from "../../../assets/images/circle.png";
@@ -39,7 +39,7 @@ export default function BallCustomization() {
           <Canvas style={styles.canvasContainer}>
             <ambientLight />
             <directionalLight position={[10, 10, 10]} intensity={1} castShadow />
-            <Ball currentBallPatternTexture={patterns[patternIndex]} />
+            <StaticBall currentBallPatternTexture={patterns[patternIndex]} />
           </Canvas>
         </View>
       </View>

--- a/src/components/StaticBall/StaticBall.jsx
+++ b/src/components/StaticBall/StaticBall.jsx
@@ -1,0 +1,28 @@
+import { useFrame } from "@react-three/fiber";
+import { useMemo, useRef } from "react";
+import * as THREE from "three";
+
+export default function StaticBall({ currentBallPatternTexture }) {
+  const mesh = useRef();
+  const texture = useMemo(() => {
+    const ballPatternTexture = new THREE.TextureLoader().load(currentBallPatternTexture);
+    ballPatternTexture.wrapS = THREE.RepeatWrapping;
+    ballPatternTexture.wrapT = THREE.RepeatWrapping;
+    ballPatternTexture.repeat.set(3, 1);
+
+    return ballPatternTexture;
+  }, [currentBallPatternTexture]);
+
+  useFrame(() => {
+    if (mesh.current) {
+      mesh.current.rotation.x -= 0.03;
+    }
+  });
+
+  return (
+    <mesh ref={mesh}>
+      <sphereGeometry args={[2, 32, 32]} />
+      <meshStandardMaterial map={texture} />
+    </mesh>
+  );
+}


### PR DESCRIPTION
## Task Kanban
[메인 화면과 로딩 화면에서 사용하는 볼 컴포넌트 분리](https://www.notion.so/ad28af6e5dff493cbc89e63aee12d190?pvs=4)

## Description
- Game3DView에서는 Ball 컴포넌트를 사용합니다.
- MainScreen과 LoadingScreen에서는 StaticBall 컴포넌트를 사용합니다.
- 메인 화면에서 선택한 공의 패턴이 로딩 화면과 게임 화면에서 동일하게 적용되게 구현했습니다.
- 메인 화면과 로딩 화면에서 공이 회전하게 구현했습니다.

## 특이사항
[공의 이동 최적화](https://www.notion.so/ed25d9069c74495bbebb1d0048d4000b?pvs=4) 부분에서 추가한 로직 중 사용하지 않는 부분이 발견되어 제거했습니다.

## 스크린샷
<img src="https://github.com/RollingArt/rollingart-project/assets/166673478/8904ba47-841a-4bc7-a0c4-34a0c104e50d" width="300">
<img src="https://github.com/RollingArt/rollingart-project/assets/166673478/0e38ac4b-53ce-4864-a6d0-a5ccc34aa54f" width="300">

## PR 전 체크리스트
- [x] 최신 브랜치를 pull하였습니다.
- [x] 리뷰어를 설정했습니다.
- [x] base 브랜치를 확인하였습니다.
- [x] 브랜치명을 확인했습니다.
- [x] 팀원이 쉽게 이해할 수 있도록, 구현 사항에 대해 설명하고 참고 자료를 제공했습니다. 