### PR TITLE
Feat: 스테이지 선택 화면 활성화, 비활성화 구현

### DIFF
--- a/app/StageScreen/Stage1Screen.jsx
+++ b/app/StageScreen/Stage1Screen.jsx
@@ -27,7 +27,7 @@ export default function Stage1Screen() {
   const [isGameResultModalVisible, setIsGameResultModalVisible] = useState(false);
   const [gameResultMessage, setGameResultMessage] = useState("");
 
-  const initialTime = 500;
+  const initialTime = 60;
   const { timeLeft, startTimer, stopTimer, resetTimer, setTimeLeft } = useTimer(initialTime);
 
   const router = useRouter();

--- a/app/StageScreen/Stage2Screen.jsx
+++ b/app/StageScreen/Stage2Screen.jsx
@@ -17,8 +17,9 @@ import decreaseImage from "../../assets/images/decrease.png";
 
 const GAME_STATE_KEY = "gameState";
 
-export default function Stage2Screen() {
+export default function Stage1Screen() {
   const [sensitiveCount, setSensitiveCount] = useState(5);
+  const [isSensitiveButtonVisible, setIsSensitiveButtonVisible] = useState(true);
   const [isPauseButtonVisible, setIsPauseButtonVisible] = useState(true);
   const [isOverlayVisible, setIsOverlayVisible] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
@@ -130,6 +131,7 @@ export default function Stage2Screen() {
   function onGameStart() {
     hasGameStarted.current = true;
     startTimer();
+    setIsSensitiveButtonVisible(false);
   }
 
   function onGameOver(message) {
@@ -148,6 +150,7 @@ export default function Stage2Screen() {
           onGameOver={onGameOver}
           isPaused={isPaused}
           reloadKey={appState.current}
+          sensitiveCount={sensitiveCount}
         />
         <View style={styles.uiContainer}>
           <TouchableOpacity onPress={handleMainButtonTouch}>
@@ -167,15 +170,17 @@ export default function Stage2Screen() {
             </TouchableOpacity>
           )}
         </View>
-        <View style={styles.countContainer}>
-          <TouchableOpacity onPress={handleDecreaseCount}>
-            <Image style={styles.Images} source={decreaseImage} />
-          </TouchableOpacity>
-          <Text style={styles.countText}>{sensitiveCount}</Text>
-          <TouchableOpacity onPress={handleIncreaseCount}>
-            <Image style={styles.Images} source={increaseImage} />
-          </TouchableOpacity>
-        </View>
+        {isSensitiveButtonVisible ? (
+          <View style={styles.countContainer}>
+            <TouchableOpacity onPress={handleDecreaseCount}>
+              <Image style={styles.Images} source={decreaseImage} />
+            </TouchableOpacity>
+            <Text style={styles.countText}>{sensitiveCount}</Text>
+            <TouchableOpacity onPress={handleIncreaseCount}>
+              <Image style={styles.Images} source={increaseImage} />
+            </TouchableOpacity>
+          </View>
+        ) : null}
       </View>
       <GameResultModal
         visible={isGameResultModalVisible}

--- a/app/StageSelectScreen/StageSelectScreen.jsx
+++ b/app/StageSelectScreen/StageSelectScreen.jsx
@@ -88,12 +88,12 @@ export default function StageSelectScreen() {
           onStageCardPress={handleStageCardButtonTouch}
         />
         <StageCardButton
-          cardDisabled={false}
-          cardButtonStyle={styles.disableCardButton}
+          cardDisabled={!(starCounts[1] >= 1)}
+          cardButtonStyle={starCounts[1] >= 1 ? styles.enableCardButton : styles.disableCardButton}
           stageLevel="Stage 2"
           id={2}
           starCount={starCounts[2] || 0}
-          onStageCardPress={handleStageCardButtonTouch}
+          onStageCardPress={starCounts[1] >= 1 ? handleStageCardButtonTouch : null}
         />
       </View>
       <CustomButton
@@ -155,7 +155,7 @@ const styles = StyleSheet.create({
     color: "#ffffff",
     fontSize: 20,
     fontWeight: "bold",
-    marginBottom: 20,
+    marginBottom: 5,
   },
   starImage: {
     height: vh(5),

--- a/app/StageSelectScreen/StageSelectScreen.jsx
+++ b/app/StageSelectScreen/StageSelectScreen.jsx
@@ -135,6 +135,7 @@ const styles = StyleSheet.create({
   disableCardButton: {
     width: vw(50),
     height: vh(18),
+    marginTop: vh(6),
     alignItems: "center",
     justifyContent: "center",
     margin: 12,


### PR DESCRIPTION
## Task Kanban
[스테이지 선택 화면 활성화, 비활성화 구현](https://www.notion.so/9f23827bc4ad415d9f48ac27c4516062?pvs=4)

## Description
- 스테이지가 오픈되지 않은 상태에서는 스테이지 진입이 불가하게 구현했습니다.
- 스테이지 1을 별 하나 이상으로 클리어 해야만 스테이지 2가 오픈되도록 구현했습니다.
- 스테이지가 오픈되기 전까지는 카드의 색상이 회색이고 stage 글씨만 보이도록 하였고, 스테이지가 오픈되면 카드의 색상이 연두색으로 변하면서 빈 별이 표시되도록 구현했습니다.

## 특이사항
X

## 스크린샷
<img src="https://github.com/RollingArt/rollingart-project/assets/166673478/bbe62596-be42-4cf2-a4f5-132a419b3a45" width="300">
<img src="https://github.com/RollingArt/rollingart-project/assets/166673478/16c12f98-2aaa-4d07-b0ad-0701f579ce15" width="300">


## PR 전 체크리스트
- [x] 최신 브랜치를 pull하였습니다.
- [x] 리뷰어를 설정했습니다.
- [x] base 브랜치를 확인하였습니다.
- [x] 브랜치명을 확인했습니다.
- [x] 팀원이 쉽게 이해할 수 있도록, 구현 사항에 대해 설명하고 참고 자료를 제공했습니다. 