### PR TITLE
Feat: ball 이동 경로 페인팅(동적으로 land 텍스처 변형) 기능 재구현

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,7 @@ module.exports = {
     "prettier/prettier": ["error", { endOfLine: "auto" }],
     "no-multiple-empty-lines": ["error", { max: 1, maxEOF: 1, maxBOF: 0 }],
     "react/no-unknown-property": ["error", { ignore: ["position", "args", "map", "rotation", "intensity", "castShadow", "receiveShadow", "object", "transparent"] }],
-    "no-param-reassign": ["error", { "props": true, "ignorePropertyModificationsFor": ["texture", "child"]}],
+    "no-param-reassign": ["error", { "props": true, "ignorePropertyModificationsFor": ["texture", "child", "landRef"]}],
     "no-unused-vars": "error",
     quotes: ["error", "double"],
     semi: ["error", "always"],

--- a/src/components/Ball/Ball.jsx
+++ b/src/components/Ball/Ball.jsx
@@ -1,7 +1,10 @@
-import { useRef, useMemo } from "react";
+import { useMemo, useRef, useEffect, useState } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 import { useSharedValue, runOnJS } from "react-native-reanimated";
+
+import ModelLoader from "../../hooks/ModelLoader";
+import getAssetUri from "../../utils/getAssetUri";
 
 export default function Ball({
   currentBallPatternTexture,
@@ -21,6 +24,9 @@ export default function Ball({
   isPaused,
   sensitiveCount,
 }) {
+  const [landModelUri, setLandModelUri] = useState(null);
+  const [landTextureUri, setLandTextureUri] = useState(null);
+
   const accumulatedQuaternion = useRef(new THREE.Quaternion());
   const position = useRef(
     new THREE.Vector3(initialPosition.x, initialPosition.y, initialPosition.z),
@@ -50,7 +56,20 @@ export default function Ball({
   const deadZoneHeight = -80;
   const collisionCheckInterval = 10;
 
-  const texture = useMemo(() => {
+  useEffect(() => {
+    async function loadModel() {
+      const modelUri = await getAssetUri(require("../../../assets/models/stageOne.glb"));
+      const textureUri = await getAssetUri(require("../../../assets/images/stageOneTexture.jpg"));
+
+      if (modelUri && textureUri) {
+        setLandModelUri(modelUri);
+        setLandTextureUri(textureUri);
+      }
+    }
+    loadModel();
+  }, []);
+
+  const ballTexture = useMemo(() => {
     const ballPatternTexture = new THREE.TextureLoader().load(currentBallPatternTexture);
     ballPatternTexture.wrapS = THREE.RepeatWrapping;
     ballPatternTexture.wrapT = THREE.RepeatWrapping;
@@ -58,6 +77,55 @@ export default function Ball({
 
     return ballPatternTexture;
   }, [currentBallPatternTexture]);
+
+  function handleModelLoad(scene) {
+    landRef.current = scene;
+  }
+
+  const dynamicTexture = useMemo(() => {
+    const size = 1024;
+    const data = new Uint8Array(size * size * 4);
+    for (let i = 0; i < size * size * 4; i += 4) {
+      data[i] = 0;
+      data[i + 1] = 0;
+      data[i + 2] = 0;
+      data[i + 3] = 0;
+    }
+    const texture = new THREE.DataTexture(data, size, size, THREE.RGBAFormat);
+    texture.needsUpdate = true;
+    return texture;
+  }, []);
+
+  const ballPosition = useRef(new THREE.Vector3());
+
+  useEffect(() => {
+    if (ballMeshRef.current) {
+      ballPosition.current.copy(ballMeshRef.current.position);
+    }
+  }, [ballMeshRef]);
+
+  function updateTexture(uvX, uvY) {
+    const radius = 3;
+    const width = 1024;
+    const height = 1024;
+    for (let i = -radius; i <= radius; i++) {
+      for (let j = -radius; j <= radius; j++) {
+        const distance = Math.sqrt(i * i + j * j);
+        if (distance <= radius) {
+          const xi = uvX + i;
+          const yj = uvY + j;
+          if (xi >= 0 && xi < width && yj >= 0 && yj < height) {
+            const index = (yj * width + xi) * 4;
+            dynamicTexture.image.data[index] = 255;
+            dynamicTexture.image.data[index + 1] = 165;
+            dynamicTexture.image.data[index + 2] = 0;
+            dynamicTexture.image.data[index + 3] = 255;
+          }
+        }
+      }
+    }
+    dynamicTexture.needsUpdate = true;
+  }
 
   function updateBallPath() {
     frameCount.current += 1;
@@ -154,14 +222,14 @@ export default function Ball({
         mesh.quaternion.copy(accumulatedQuaternion.current);
         mesh.position.set(position.current.x, position.current.y, position.current.z);
 
-        const ballPosition = mesh.position;
+        const ballCurrentPosition = mesh.position;
         const startBox = new THREE.Box3().setFromObject(startZoneRef.current);
         const endBox = new THREE.Box3().setFromObject(endZoneRef.current);
 
-        if (startBox.containsPoint(ballPosition)) {
+        if (startBox.containsPoint(ballCurrentPosition)) {
           runOnJS(onGameStart)();
         }
-        if (endBox.containsPoint(ballPosition)) {
+        if (endBox.containsPoint(ballCurrentPosition)) {
           runOnJS(onGameOver)("finish");
         }
       }
@@ -185,14 +253,96 @@ export default function Ball({
       rotationX.value = accumulatedQuaternion.current.x;
       rotationZ.value = accumulatedQuaternion.current.z;
 
+      if (ballMeshRef.current) {
+        const mesh = ballMeshRef.current;
+        mesh.quaternion.copy(accumulatedQuaternion.current);
+        mesh.position.set(position.current.x, position.current.y, position.current.z);
+
+        const ballPositionVector = new THREE.Vector3(
+          position.current.x,
+          position.current.y,
+          position.current.z,
+        );
+
+        ballPosition.current.copy(ballPositionVector);
+
+        const startBox = new THREE.Box3().setFromObject(startZoneRef.current);
+        const endBox = new THREE.Box3().setFromObject(endZoneRef.current);
+
+        if (startBox.containsPoint(ballPositionVector)) {
+          runOnJS(onGameStart)();
+        }
+        if (endBox.containsPoint(ballPositionVector)) {
+          runOnJS(onGameOver)("finish");
+        }
+      }
+
+      if (frameCount.current % collisionCheckInterval === 0) {
+        const colliders = [...colliderRefs.current];
+        const collisionDetected = colliders.some((collider) =>
+          new THREE.Box3().setFromObject(collider).containsPoint(position.current),
+        );
+
+        if (collisionDetected) {
+          position.current.copy(previousPosition.current);
+          velocity.current.set(0, 0, 0);
+        }
+      }
+
+      positionX.value = position.current.x;
+      positionY.value = position.current.y;
+      positionZ.value = position.current.z;
+
+      rotationX.value = accumulatedQuaternion.current.x;
+      rotationZ.value = accumulatedQuaternion.current.z;
+
+      if (landRef.current) {
+        const ballPositionVector = new THREE.Vector3(
+          position.current.x,
+          position.current.y,
+          position.current.z,
+        );
+        landRef.current.traverse((child) => {
+          if (
+            child.isMesh &&
+            child.material &&
+            child.material.uniforms &&
+            child.material.uniforms.ballPosition
+          ) {
+            if (child.material.uniforms.ballPosition.value instanceof THREE.Vector3) {
+              child.material.uniforms.ballPosition.value.copy(ballPositionVector);
+              child.material.uniforms.dynamicTexture.value.needsUpdate = true;
+            }
+          }
+        });
+      }
+
       updateBallPath();
+      const uv = intersects[0]?.uv;
+      if (uv) {
+        const uvX = Math.floor(uv.x * 1024);
+        const uvY = Math.floor(uv.y * 1024);
+        updateTexture(uvX, uvY);
+      }
     }
   });
 
   return (
-    <mesh ref={ballMeshRef} castShadow>
-      <sphereGeometry args={[1, 16, 16]} />
-      <meshStandardMaterial map={texture} />
-    </mesh>
+    <>
+      <mesh ref={ballMeshRef} castShadow>
+        <sphereGeometry args={[1, 16, 16]} />
+        <meshStandardMaterial map={ballTexture} />
+      </mesh>
+      {landModelUri && (
+        <ModelLoader
+          modelUri={landModelUri}
+          textureUri={landTextureUri}
+          onLoad={handleModelLoad}
+          dynamicTexture={dynamicTexture}
+          ballPosition={position.current}
+          brushRadius={0.01}
+        />
+      )}
+    </>
   );
 }

--- a/src/hooks/ModelLoader.jsx
+++ b/src/hooks/ModelLoader.jsx
@@ -2,7 +2,37 @@ import { useEffect } from "react";
 import { useGLTF } from "@react-three/drei/native";
 import * as THREE from "three";
 
-export default function ModelLoader({ modelUri, textureUri, onLoad }) {
+const fragmentShader = `
+  uniform sampler2D baseTexture;
+  uniform sampler2D dynamicTexture;
+  uniform vec3 ballPosition;
+  uniform float brushRadius;
+  varying vec2 vUv;
+
+  void main() {
+    vec4 baseColor = texture2D(baseTexture, vUv);
+    vec4 dynamicColor = texture2D(dynamicTexture, vUv);
+    vec2 uv = vUv;
+
+    vec2 projectedPosition = vec2(ballPosition.x, ballPosition.z);
+    float distance = length(uv - projectedPosition);
+
+    if (distance < brushRadius) {
+      dynamicColor = vec4(1.0, 0.0, 0.0, 1.0);
+    }
+
+    gl_FragColor = mix(baseColor, dynamicColor, dynamicColor.a);
+  }
+`;
+
+export default function ModelLoader({
+  modelUri,
+  textureUri,
+  onLoad,
+  dynamicTexture,
+  ballPosition,
+  brushRadius,
+}) {
   const { scene } = useGLTF(modelUri);
 
   useEffect(() => {
@@ -16,12 +46,32 @@ export default function ModelLoader({ modelUri, textureUri, onLoad }) {
         texture.minFilter = THREE.LinearMipmapLinearFilter;
         texture.magFilter = THREE.LinearFilter;
 
-        const landMaterial = new THREE.MeshStandardMaterial({ map: texture });
+        const uniforms = {
+          baseTexture: { value: texture },
+          dynamicTexture: { value: dynamicTexture },
+          ballPosition: { value: ballPosition || { x: 0, y: 0, z: 0 } },
+          brushRadius: { value: brushRadius },
+        };
+
+        const landMaterial = new THREE.ShaderMaterial({
+          uniforms,
+          vertexShader: `
+            varying vec2 vUv;
+            void main() {
+              vUv = uv;
+              gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+            }
+          `,
+          fragmentShader,
+        });
 
         scene.traverse((child) => {
           if (child.isMesh) {
             if (child.name === "stageOneLand") {
               child.material = landMaterial;
+              if (!child.geometry.boundingBox) {
+                child.geometry.computeBoundingBox();
+              }
             } else if (child.name === "fence") {
               child.material = BeigeMaterial;
             }
@@ -34,7 +84,7 @@ export default function ModelLoader({ modelUri, textureUri, onLoad }) {
         onLoad(scene);
       });
     }
-  }, [scene, textureUri, onLoad]);
+  }, [scene, textureUri, onLoad, dynamicTexture, ballPosition, brushRadius]);
 
   return null;
 }


### PR DESCRIPTION
## Task Kanban
[동적 텍스처 변형 구현(그래픽 처리)](https://www.notion.so/1b04c20258a24e7bb0d3c6bf1fd48a91?pvs=4)

## Description
- 공의 이동 경로에 따라 land의 텍스처가 동적으로 변형되게 구현했습니다.
    - 공의 월드 좌표를 구한 뒤, 레이캐스터를 통해 land와의 교차점을 찾습니다.
    - 교차점의 좌표값을 land 텍스처의 uv 좌표로 변환합니다.
    - 텍스처의 uv좌표를 픽셀 좌표로 변환한 뒤 텍스처에서 해당 픽셀을 찾아 공의 지름 영역만큼 색상을 변경합니다.
- 위 기능을 Three.js의 [DataTexture](https://threejs.org/docs/#api/en/textures/DataTexture)를 통해 최적화 하였습니다.
    - 픽셀 데이터를 담고있는 배열 형태의 텍스처를 생성하였습니다.
    - 공이 이동할 때마다 전체 텍스처가 리렌더링 되는 것이 아닌, 필요한 영역에(새로이 그려져야하는 영역) 대해서만 업데이트가 이루어지게 구현했습니다.

## 특이사항
**1. esLint**
- esLint 일부 규칙이 재설정 되었습니다. 그래픽 구현에 필요한 특정 속성에 대해서만 규칙을 꺼두었습니다.

**2. 구현 관련**
- [기존 GLView를 활용해 구현한 기능](https://github.com/RollingArt/rollingart-project/pull/20)에서 심각한 성능 저하가 일어나고 있음을 확인했습니다.
- 원인을 추적하던 중, react three fiber를 사용하는 환경에서 expo-gl의 GLView를 사용하는 것의 어려움, 호환성의 문제에 대해 알게 되었습니다.
    - GLView를 통한 재구현을 시도하다가 개발의 복잡도에 비해 성능 개선 효과가 기대만큼 크지 않을 수 있겠다고 판단하였습니다.
    - GLView는 화면 전체에 대해 렌더링해야하는 경우에 더 적합합니다.
    - 현재 기능의 경우 텍스처의 특정 영역에 대한 연산이 필요한 것이라, 데이터 텍스처링이 더욱 적합합니다.
    - 또한, 데이터 텍스처링은 Three.js와 React Three Fiber를 사용하는 현재 프로젝트 세팅 환경에 완벽히 호환됩니다.
    - 위와 같은 이유로 데이터 텍스처링을 통한 최적화를 진행했습니다.

## 스크린샷
<img src="https://github.com/RollingArt/rollingart-project/assets/160200515/6c327695-d74a-472f-b8a5-f4f1a810f8b3" width="300">


## PR 전 체크리스트
- [x] 최신 브랜치를 pull하였습니다.
- [x] 리뷰어를 설정했습니다.
- [x] base 브랜치를 확인하였습니다.
- [x] 브랜치명을 확인했습니다.
- [x] 팀원이 쉽게 이해할 수 있도록, 구현 사항에 대해 설명하고 참고 자료를 제공했습니다.