### PR TITLE
Fix: ball 컴포넌트 중복 코드 삭제

### DIFF
--- a/src/components/Ball/Ball.jsx
+++ b/src/components/Ball/Ball.jsx
@@ -222,42 +222,6 @@ export default function Ball({
         mesh.quaternion.copy(accumulatedQuaternion.current);
         mesh.position.set(position.current.x, position.current.y, position.current.z);
 
-        const ballCurrentPosition = mesh.position;
-        const startBox = new THREE.Box3().setFromObject(startZoneRef.current);
-        const endBox = new THREE.Box3().setFromObject(endZoneRef.current);
-
-        if (startBox.containsPoint(ballCurrentPosition)) {
-          runOnJS(onGameStart)();
-        }
-        if (endBox.containsPoint(ballCurrentPosition)) {
-          runOnJS(onGameOver)("finish");
-        }
-      }
-
-      if (frameCount.current % collisionCheckInterval === 0) {
-        const colliders = [...colliderRefs.current];
-        const collisionDetected = colliders.some((collider) =>
-          new THREE.Box3().setFromObject(collider).containsPoint(position.current),
-        );
-
-        if (collisionDetected) {
-          position.current.copy(previousPosition.current);
-          velocity.current.set(0, 0, 0);
-        }
-      }
-
-      positionX.value = position.current.x;
-      positionY.value = position.current.y;
-      positionZ.value = position.current.z;
-
-      rotationX.value = accumulatedQuaternion.current.x;
-      rotationZ.value = accumulatedQuaternion.current.z;
-
-      if (ballMeshRef.current) {
-        const mesh = ballMeshRef.current;
-        mesh.quaternion.copy(accumulatedQuaternion.current);
-        mesh.position.set(position.current.x, position.current.y, position.current.z);
-
         const ballPositionVector = new THREE.Vector3(
           position.current.x,
           position.current.y,


### PR DESCRIPTION
## Description
- ball 컴포넌트 useFrame 훅 내부에 중복 코드로 인해 타이머가 제대로 작동하지 않는 버그가 발생했습니다.
- 중복 코드를 삭제해 버그 수정했습니다.

## 특이사항
- land 텍스처 변형 구현 중 이전 커밋의 코드를 가져오는 과정에서 생겨난 중복 코드로 판단됩니다.
- 실수 없도록 코드 꼼꼼히 확인하겠습니다.

## PR 전 체크리스트
- [x] 최신 브랜치를 pull하였습니다.
- [x] 리뷰어를 설정했습니다.
- [x] base 브랜치를 확인하였습니다.
- [x] 브랜치명을 확인했습니다.
- [x] 팀원이 쉽게 이해할 수 있도록, 구현 사항에 대해 설명하고 참고 자료를 제공했습니다. 