### PR TITLE
Fix: 공이 지면에서 추락하는 버그 수정

### DIFF
--- a/src/components/Ball/Ball.jsx
+++ b/src/components/Ball/Ball.jsx
@@ -134,7 +134,7 @@ export default function Ball({
 
       let landHeight = null;
       let landSlopeX = 0;
-      let landSlopeY = 0;
+      let landSlopeZ = 0;
       const slopeThreshold = 1;
 
       raycaster.current.set(
@@ -153,23 +153,24 @@ export default function Ball({
 
         const { normal } = intersects[0].face;
         landSlopeX = Math.abs(normal.x) > slopeThreshold ? normal.x : 0;
-        landSlopeY = Math.abs(normal.y) > slopeThreshold ? normal.y : 0;
+        landSlopeZ = Math.abs(normal.z) > slopeThreshold ? normal.z : 0;
       } else if (position.current.y < deadZoneHeight) {
         onGameOver("fall");
       }
 
       velocity.current.x += (extraTiltX + landSlopeX) * delta * (sensitiveCount + 3);
-      velocity.current.z += (extraTiltY + landSlopeY) * delta * (sensitiveCount + 3);
+      velocity.current.z += (extraTiltY + landSlopeZ) * delta * (sensitiveCount + 3);
       velocity.current.y += gravity * delta;
 
       velocity.current.x *= 1 - friction * delta;
       velocity.current.z *= 1 - friction * delta;
 
-      if (Math.abs(velocity.current.x) > 0.1 || Math.abs(velocity.current.z) > 0.1) {
-        position.current.x += velocity.current.x * delta * 2;
-        position.current.z += velocity.current.z * delta * 2;
-        position.current.y += velocity.current.y * delta * 2;
-      }
+      if (Math.abs(velocity.current.x) < 0.05) velocity.current.x = 0;
+      if (Math.abs(velocity.current.z) < 0.05) velocity.current.z = 0;
+
+      position.current.x += velocity.current.x * delta * 2;
+      position.current.z += velocity.current.z * delta * 2;
+      position.current.y += velocity.current.y * delta * 2;
 
       const moveDirection = new THREE.Vector3(
         velocity.current.x,


### PR DESCRIPTION
## Task Kanban
[버그 수정](https://www.notion.so/145186a3b8ea46fea1a8592694341e27?pvs=4)

## Description
- 공이 제자리에 가만히 있거나 아주 느린 속도로 움직이면 화면이 튀거나 공이 갑자기 추락하는 버그가 있었습니다.
- 공의 위치를 업데이트하는 코드에 적용된 조건문의 문제였습니다.
  ```js
  if (Math.abs(velocity.current.x) > 0.1 || Math.abs(velocity.current.z) > 0.1) {
    position.current.x += velocity.current.x * delta * 2;
    position.current.z += velocity.current.z * delta * 2;
    position.current.y += velocity.current.y * delta * 2;
  }
  ```
- x축이나 z축 속도가 일정 값 이상일 때만 위치를 업데이트하도록 구현되어 있었습니다.
- 이로 인해 공이 느리게 움직일 때 위치가 업데이트되지 않아서 공이 지형 위에 떠 있거나, 갑자기 추락하는 현상이 발생했습니다.
- 해당 조건문을 지우고 아주 작은 값의 속도에서는 아예 속도를 0으로 처리하도록 코드를 추가했습니다.
  ```js
  if (Math.abs(velocity.current.x) < 0.05) velocity.current.x = 0;
  if (Math.abs(velocity.current.z) < 0.05) velocity.current.z = 0;
  
  position.current.x += velocity.current.x * delta * 2;
  position.current.z += velocity.current.z * delta * 2;
  position.current.y += velocity.current.y * delta * 2;
  ```

## 특이사항
- 아직 공이 가만히 있을 때 아주 미세한 떨림이 있는 것 같은데요. 게임 플레이에는 지장이 없는 수준입니다. 기능 구현 완료 후 원인을 파악해봐야할 거 같습니다.

## 스크린샷
<img src="https://github.com/RollingArt/rollingart-project/assets/160200515/86a4d0b6-c0df-4b11-9d21-280a3a053a6b" width="300">
<img src="https://github.com/RollingArt/rollingart-project/assets/160200515/18b5a089-0249-4d38-9285-24d44eb64ee1" width="300">

좌측이 수정 전, 우측이 수정 후입니다.

## PR 전 체크리스트
- [x] 최신 브랜치를 pull하였습니다.
- [x] 리뷰어를 설정했습니다.
- [x] base 브랜치를 확인하였습니다.
- [x] 브랜치명을 확인했습니다.
- [x] 팀원이 쉽게 이해할 수 있도록, 구현 사항에 대해 설명하고 참고 자료를 제공했습니다. 