### PR TITLE
Feat: 앱 종료 구현

### DIFF
--- a/app/MainScreen/MainScreen.jsx
+++ b/app/MainScreen/MainScreen.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { View, Image, StyleSheet } from "react-native";
+import { View, Image, StyleSheet, Platform, BackHandler } from "react-native";
 import { useRouter } from "expo-router";
 import { vw, vh } from "react-native-expo-viewport-units";
 
@@ -21,6 +21,12 @@ export default function MainScreen() {
     setIsExitGameModalVisible(false);
   }
 
+  function handleExitButtonTouch() {
+    if (Platform.OS === "android") {
+      BackHandler.exitApp();
+    }
+  }
+
   async function handleStartButtonTouch() {
     router.replace("/StageSelectScreen/StageSelectScreen");
   }
@@ -37,17 +43,19 @@ export default function MainScreen() {
             buttonText="게임 시작"
             onPress={handleStartButtonTouch}
           />
-          <CustomButton
-            containerStyle={[styles.button, styles.black]}
-            textStyle={styles.text}
-            buttonText="게임 종료"
-            onPress={handleOpenModal}
-          />
+          {Platform.OS === "ios" ? null : (
+            <CustomButton
+              containerStyle={[styles.button, styles.black]}
+              textStyle={styles.text}
+              buttonText="게임 종료"
+              onPress={handleOpenModal}
+            />
+          )}
         </View>
       </View>
       <ConfirmationModal
         visible={isExitGameModalVisible}
-        onLeftButtonTouch={null}
+        onLeftButtonTouch={handleExitButtonTouch}
         onRightButtonTouch={handleCloseModal}
         modalMessage="게임을 종료하시겠습니까?"
       />
@@ -65,13 +73,13 @@ const styles = StyleSheet.create({
   },
   logoImage: {
     width: vw(70),
-    marginTop: vh(8),
+    marginTop: Platform.OS === "ios" ? vh(13) : vh(8),
     resizeMode: "contain",
   },
   button: {
     width: vw(70),
     height: vh(7),
-    marginBottom: vw(5),
+    marginBottom: Platform.OS === "ios" ? vh(20) : vw(5),
     borderRadius: 10,
   },
   brightGreen: {


### PR DESCRIPTION
## Task Kanban
[앱 종료 구현](https://www.notion.so/ba5d56f1370740b8a8adbdd3d63276bc?pvs=4)

## Description
- 게임 종료 버튼을 터치하고 종료하면 앱이 종료되도록 구현했습니다.
- 다시 접속했을 때  저장된 이전 데이터가 남아있도록 구현했습니다.

## 특이사항
- ios에서는 앱 종료를 지원하지 않아 앱의 종료에 대한 구현은 하지 못했습니다.
- alert을 띄우는 방법이 존재했지만 UX면에서 사용성이 많이 떨어진다고 판단되어 android에서는 버튼이 보이도록 하고, ios에서는 버튼이 보이지 않게 구현했습니다.

## 스크린샷
<img src="https://github.com/RollingArt/rollingart-project/assets/166673478/27b87d49-72d1-403f-8d6f-fdc3e9de1884" width="300">

## PR 전 체크리스트
- [x] 최신 브랜치를 pull하였습니다.
- [x] 리뷰어를 설정했습니다.
- [x] base 브랜치를 확인하였습니다.
- [x] 브랜치명을 확인했습니다.
- [x] 팀원이 쉽게 이해할 수 있도록, 구현 사항에 대해 설명하고 참고 자료를 제공했습니다. 