### PR TITLE
Feat: 로딩 구현 및 카메라 조정

### DIFF
--- a/app/Game3DScene/Game3DScene.jsx
+++ b/app/Game3DScene/Game3DScene.jsx
@@ -29,6 +29,10 @@ export default function Game3DScreen({
   setCorrectPath,
   ballPath,
   handlePathUpdate,
+  setIsLoading,
+  isLoading,
+  setIsAnimating,
+  isAnimating,
 }) {
   const landRef = useRef();
   const ballMeshRef = useRef();
@@ -36,12 +40,13 @@ export default function Game3DScreen({
   const endZoneRef = useRef();
   const colliderRefs = useRef([]);
 
-  const ballPositionRef = useRef(new THREE.Vector3());
+  const ballPositionRef = useRef(new THREE.Vector3(0, 1, 140));
   const [dynamicTexture, setDynamicTexture] = useState(null);
 
   const [isGameStarted, setIsGameStarted] = useState(false);
   const [isGameOver, setIsGameOver] = useState(false);
   const [landLoaded, setLandLoaded] = useState(false);
+  const [isBallLoaded, setIsBallLoaded] = useState(false);
 
   const [patternIndex, setPatternIndex] = useState(0);
   const patterns = useMemo(() => [patternTexture1, patternTexture2, patternTexture3]);
@@ -51,7 +56,7 @@ export default function Game3DScreen({
 
   const [accelData, setAccelData] = useState({ x: 0, y: 0, z: 0 });
   const initialTilt = useRef({ x: 0, y: 0, z: 0 });
-  const position = useRef({ x: 0, y: 0, z: 140 });
+  const position = useRef({ x: 0, y: 1, z: 140 });
   const velocity = useRef({ x: 0, y: 0, z: 0 });
   const friction = 1.2;
 
@@ -65,6 +70,15 @@ export default function Game3DScreen({
     texture.needsUpdate = true;
     setDynamicTexture(texture);
   }, []);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (landLoaded && isBallLoaded && isLoading) {
+        setIsLoading(false);
+      }
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [landLoaded, isBallLoaded, isLoading]);
 
   const handleLoadModel = useCallback(
     (scene) => {
@@ -218,7 +232,11 @@ export default function Game3DScreen({
       <Canvas shadows>
         <ambientLight color={0xffffff} intensity={0.6} />
         <directionalLight color={0xffffff} intensity={1} position={[5, 5, 5]} castShadow />
-        <CameraController followTarget={ballMeshRef} />
+        <CameraController
+          followTarget={ballMeshRef}
+          isAnimating={isAnimating}
+          setIsAnimating={setIsAnimating}
+        />
         {currentStage === 0 && <TutorialStageLand setLandRef={handleLoadModel} />}
         {currentStage === 1 && (
           <Stage1Land
@@ -242,40 +260,38 @@ export default function Game3DScreen({
             setCorrectPath={setCorrectPath}
           />
         )}
-        {landLoaded && (
-          <>
-            <Ball
-              ballMeshRef={ballMeshRef}
-              currentBallPatternTexture={selectedPattern}
-              initialPosition={position.current}
-              initialVelocity={velocity.current}
-              accelData={accelData}
-              friction={friction}
-              initialTilt={initialTilt}
-              handlePathUpdate={handlePathUpdate}
-              landRef={landRef}
-              startZoneRef={startZoneRef}
-              endZoneRef={endZoneRef}
-              colliderRefs={colliderRefs}
-              onGameStart={handleGameStart}
-              onGameOver={handleGameOver}
-              isPaused={isPaused}
-              sensitiveCount={sensitiveCount}
-              currentStage={currentStage}
-              correctPath={correctPath}
-              ballPath={ballPath}
-              updateBallPosition={handleUpdateBallPosition}
-              dynamicTexture={dynamicTexture}
-              castShadow
-            />
-            <DynamicTextureApplier
-              scene={landRef.current}
-              dynamicTexture={dynamicTexture}
-              ballPosition={ballPositionRef.current}
-              brushRadius={0.01}
-            />
-          </>
-        )}
+        <Ball
+          ballMeshRef={ballMeshRef}
+          currentBallPatternTexture={selectedPattern}
+          initialPosition={position.current}
+          initialVelocity={velocity.current}
+          accelData={accelData}
+          friction={friction}
+          initialTilt={initialTilt}
+          handlePathUpdate={handlePathUpdate}
+          landRef={landRef}
+          startZoneRef={startZoneRef}
+          endZoneRef={endZoneRef}
+          colliderRefs={colliderRefs}
+          onGameStart={handleGameStart}
+          onGameOver={handleGameOver}
+          isPaused={isPaused}
+          sensitiveCount={sensitiveCount}
+          currentStage={currentStage}
+          correctPath={correctPath}
+          ballPath={ballPath}
+          updateBallPosition={handleUpdateBallPosition}
+          dynamicTexture={dynamicTexture}
+          setIsBallLoaded={setIsBallLoaded}
+          isAnimating={isAnimating}
+          castShadow
+        />
+        <DynamicTextureApplier
+          scene={landRef.current}
+          dynamicTexture={dynamicTexture}
+          ballPosition={ballPositionRef.current}
+          brushRadius={0.01}
+        />
       </Canvas>
       {isOverlayVisible && <View style={styles.overlayContainer} />}
     </View>

--- a/app/Game3DScene/Game3DScene.jsx
+++ b/app/Game3DScene/Game3DScene.jsx
@@ -85,7 +85,7 @@ export default function Game3DScreen({
       landRef.current = scene;
       setLandLoaded(true);
     },
-    [correctPath],
+    [landRef],
   );
 
   const handleUpdateBallPosition = useCallback((newPosition) => {

--- a/app/StageScreen/Stage0Screen.jsx
+++ b/app/StageScreen/Stage0Screen.jsx
@@ -4,6 +4,7 @@ import { useRouter } from "expo-router";
 import { vh, vw } from "react-native-expo-viewport-units";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
+import LoadingScreen from "../LoadingScreen/LoadingScreen";
 import Game3DScene from "../Game3DScene/Game3DScene";
 import useTimer from "../../src/hooks/useTimer";
 import ConfirmationModal from "../../src/components/ConfirmationModal/ConfirmationModal";
@@ -20,6 +21,8 @@ import decreaseImage from "../../assets/images/decrease.png";
 const GAME_STATE_KEY = "gameState";
 
 export default function Stage0Screen() {
+  const [isLoading, setIsLoading] = useState(true);
+  const [isAnimating, setIsAnimating] = useState(true);
   const [sensitiveCount, setSensitiveCount] = useState(5);
   const [isPauseButtonVisible, setIsPauseButtonVisible] = useState(true);
   const [isOverlayVisible, setIsOverlayVisible] = useState(false);
@@ -151,6 +154,20 @@ export default function Stage0Screen() {
 
   return (
     <>
+      {isLoading && (
+        <View style={styles.loadingOverlay}>
+          <LoadingScreen />
+        </View>
+      )}
+      {isAnimating && (
+        <View style={styles.centered}>
+          <View style={styles.textInfoContainer}>
+            <Text style={styles.infoText}>
+              자유롭게 그리며 <Text style={styles.specialText}>조작감</Text>을 익혀보세요!
+            </Text>
+          </View>
+        </View>
+      )}
       <View style={styles.container}>
         <Game3DScene
           isOverlayVisible={isOverlayVisible}
@@ -160,6 +177,10 @@ export default function Stage0Screen() {
           reloadKey={appState.current}
           sensitiveCount={sensitiveCount}
           currentStage={currentStage}
+          setIsLoading={setIsLoading}
+          isLoading={isLoading}
+          setIsAnimating={setIsAnimating}
+          isAnimating={isAnimating}
         />
         <View style={styles.uiContainer}>
           <TouchableOpacity onPress={handleMainButtonTouch}>
@@ -194,15 +215,17 @@ export default function Stage0Screen() {
           </TouchableOpacity>
         </View>
       </View>
-      <GameDescriptionModal
-        setIsPaused={setIsPaused}
-        onGameStart={onGameStart}
-        setIsGameDescriptionModalVisible={setIsGameDescriptionModalVisible}
-        isGameDescriptionModalVisible={isGameDescriptionModalVisible}
-        isPauseButtonVisible={isPauseButtonVisible}
-        descriptionImages={descriptionImages}
-        setDescriptionImages={setDescriptionImages}
-      />
+      {!isLoading && !isAnimating && (
+        <GameDescriptionModal
+          setIsPaused={setIsPaused}
+          onGameStart={onGameStart}
+          setIsGameDescriptionModalVisible={setIsGameDescriptionModalVisible}
+          isGameDescriptionModalVisible={isGameDescriptionModalVisible}
+          isPauseButtonVisible={isPauseButtonVisible}
+          descriptionImages={descriptionImages}
+          setDescriptionImages={setDescriptionImages}
+        />
+      )}
       <TutorialResultModal visible={isGameResultModalVisible} currentStage={currentStage} />
       <ConfirmationModal
         visible={isMainModalVisible}
@@ -275,5 +298,38 @@ const styles = StyleSheet.create({
     fontSize: 50,
     fontWeight: "bold",
     color: "#49a246",
+  },
+  textInfoContainer: {
+    justifyContent: "center",
+    alignItems: "center",
+    width: vw(90),
+    height: vh(7),
+    top: 130,
+    backgroundColor: "rgba(255, 255, 255, 0.7)",
+    borderRadius: 10,
+    zIndex: 1,
+  },
+  infoText: {
+    fontSize: 20,
+    textAlign: "center",
+    fontWeight: "bold",
+    color: "#0f0f0f",
+    textShadowColor: "#fff",
+    textShadowOffset: { width: 1, height: 1 },
+    textShadowRadius: 2,
+  },
+  centered: {
+    width: vw(100),
+    position: "absolute",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  specialText: {
+    color: "#ff7f00",
+  },
+  loadingOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 10,
+    backgroundColor: "#fff",
   },
 });

--- a/app/StageScreen/Stage1Screen.jsx
+++ b/app/StageScreen/Stage1Screen.jsx
@@ -207,7 +207,7 @@ export default function Stage1Screen() {
             <Image style={styles.Images} source={MainButtonImage} />
           </TouchableOpacity>
           <View style={styles.textContainer}>
-            <Text style={styles.stageText}>stage 1</Text>
+            <Text style={styles.stageText}>Stage 1</Text>
             <Text style={styles.timeText}>{timeLeft}</Text>
           </View>
           {isPauseButtonVisible ? (
@@ -306,10 +306,10 @@ const styles = StyleSheet.create({
     fontSize: 20,
     textAlign: "center",
     fontWeight: "bold",
-    color: "#0f0f0f", // Text 색상
-    textShadowColor: "#fff", // 테두리 색상
+    color: "#0f0f0f",
+    textShadowColor: "#fff",
     textShadowOffset: { width: 1, height: 1 },
-    textShadowRadius: 2, // 테두리 둥글기
+    textShadowRadius: 2,
   },
   Images: {
     width: vw(10),
@@ -337,6 +337,6 @@ const styles = StyleSheet.create({
     backgroundColor: "#fff",
   },
   specialText: {
-    color: "#ff7f00", // 특정 글자의 색상 변경
+    color: "#ff7f00",
   },
 });

--- a/app/StageScreen/Stage1Screen.jsx
+++ b/app/StageScreen/Stage1Screen.jsx
@@ -4,6 +4,7 @@ import { useRouter } from "expo-router";
 import { vh, vw } from "react-native-expo-viewport-units";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
+import LoadingScreen from "../LoadingScreen/LoadingScreen";
 import Game3DScene from "../Game3DScene/Game3DScene";
 import useTimer from "../../src/hooks/useTimer";
 import ConfirmationModal from "../../src/components/ConfirmationModal/ConfirmationModal";
@@ -19,6 +20,8 @@ import decreaseImage from "../../assets/images/decrease.png";
 const GAME_STATE_KEY = "gameState";
 
 export default function Stage1Screen() {
+  const [isLoading, setIsLoading] = useState(true);
+  const [isAnimating, setIsAnimating] = useState(true);
   const [sensitiveCount, setSensitiveCount] = useState(5);
   const [isSensitiveButtonVisible, setIsSensitiveButtonVisible] = useState(true);
   const [isPauseButtonVisible, setIsPauseButtonVisible] = useState(true);
@@ -167,6 +170,20 @@ export default function Stage1Screen() {
 
   return (
     <>
+      {isLoading && (
+        <View style={styles.loadingOverlay}>
+          <LoadingScreen />
+        </View>
+      )}
+      {isAnimating && (
+        <View style={styles.centered}>
+          <View style={styles.textInfoContainer}>
+            <Text style={styles.infoText}>
+              길을 따라 <Text style={styles.specialText}>원</Text>을 정확하게 그려보세요!
+            </Text>
+          </View>
+        </View>
+      )}
       <View style={styles.container}>
         <Game3DScene
           isOverlayVisible={isOverlayVisible}
@@ -180,6 +197,10 @@ export default function Stage1Screen() {
           setCorrectPath={setCorrectPath}
           handlePathUpdate={handlePathUpdate}
           ballPath={ballPath}
+          setIsLoading={setIsLoading}
+          isLoading={isLoading}
+          setIsAnimating={setIsAnimating}
+          isAnimating={isAnimating}
         />
         <View style={styles.uiContainer}>
           <TouchableOpacity onPress={handleMainButtonTouch}>
@@ -211,7 +232,7 @@ export default function Stage1Screen() {
           </View>
         ) : null}
       </View>
-      <ChallengeModal currentStage={currentStage} setIsPaused={setIsPaused} />
+      {!isAnimating && <ChallengeModal currentStage={currentStage} setIsPaused={setIsPaused} />}
       <GameResultModal
         visible={isGameResultModalVisible}
         currentStage={currentStage}
@@ -265,6 +286,31 @@ const styles = StyleSheet.create({
     borderColor: "#49a246",
     backgroundColor: "rgba(218, 247, 217, 0.4)",
   },
+  textInfoContainer: {
+    justifyContent: "center",
+    alignItems: "center",
+    width: vw(90),
+    height: vh(7),
+    top: 130,
+    backgroundColor: "rgba(255, 255, 255, 0.7)",
+    borderRadius: 10,
+    zIndex: 1,
+  },
+  centered: {
+    width: vw(100),
+    position: "absolute",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  infoText: {
+    fontSize: 20,
+    textAlign: "center",
+    fontWeight: "bold",
+    color: "#0f0f0f", // Text 색상
+    textShadowColor: "#fff", // 테두리 색상
+    textShadowOffset: { width: 1, height: 1 },
+    textShadowRadius: 2, // 테두리 둥글기
+  },
   Images: {
     width: vw(10),
     height: vh(10),
@@ -284,5 +330,13 @@ const styles = StyleSheet.create({
     fontSize: 50,
     fontWeight: "bold",
     color: "#49a246",
+  },
+  loadingOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 10,
+    backgroundColor: "#fff",
+  },
+  specialText: {
+    color: "#ff7f00", // 특정 글자의 색상 변경
   },
 });

--- a/app/StageScreen/Stage2Screen.jsx
+++ b/app/StageScreen/Stage2Screen.jsx
@@ -179,7 +179,7 @@ export default function Stage2Screen() {
         <View style={styles.centered}>
           <View style={styles.textInfoContainer}>
             <Text style={styles.infoText}>
-              길을 따라 <Text style={styles.specialText}>토끼</Text>을 정확하게 그려보세요!
+              길을 따라 <Text style={styles.specialText}>토끼</Text>를 정확하게 그려보세요!
             </Text>
           </View>
         </View>

--- a/app/StageScreen/Stage2Screen.jsx
+++ b/app/StageScreen/Stage2Screen.jsx
@@ -4,6 +4,7 @@ import { useRouter } from "expo-router";
 import { vh, vw } from "react-native-expo-viewport-units";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
+import LoadingScreen from "../LoadingScreen/LoadingScreen";
 import Game3DScene from "../Game3DScene/Game3DScene";
 import useTimer from "../../src/hooks/useTimer";
 import ConfirmationModal from "../../src/components/ConfirmationModal/ConfirmationModal";
@@ -19,6 +20,8 @@ import decreaseImage from "../../assets/images/decrease.png";
 const GAME_STATE_KEY = "gameState";
 
 export default function Stage2Screen() {
+  const [isLoading, setIsLoading] = useState(true);
+  const [isAnimating, setIsAnimating] = useState(true);
   const [sensitiveCount, setSensitiveCount] = useState(5);
   const [isSensitiveButtonVisible, setIsSensitiveButtonVisible] = useState(true);
   const [isPauseButtonVisible, setIsPauseButtonVisible] = useState(true);
@@ -167,6 +170,20 @@ export default function Stage2Screen() {
 
   return (
     <>
+      {isLoading && (
+        <View style={styles.loadingOverlay}>
+          <LoadingScreen />
+        </View>
+      )}
+      {isAnimating && (
+        <View style={styles.centered}>
+          <View style={styles.textInfoContainer}>
+            <Text style={styles.infoText}>
+              길을 따라 <Text style={styles.specialText}>토끼</Text>을 정확하게 그려보세요!
+            </Text>
+          </View>
+        </View>
+      )}
       <View style={styles.container}>
         <Game3DScene
           isOverlayVisible={isOverlayVisible}
@@ -180,13 +197,17 @@ export default function Stage2Screen() {
           setCorrectPath={setCorrectPath}
           handlePathUpdate={handlePathUpdate}
           ballPath={ballPath}
+          setIsLoading={setIsLoading}
+          isLoading={isLoading}
+          setIsAnimating={setIsAnimating}
+          isAnimating={isAnimating}
         />
         <View style={styles.uiContainer}>
           <TouchableOpacity onPress={handleMainButtonTouch}>
             <Image style={styles.Images} source={MainButtonImage} />
           </TouchableOpacity>
           <View style={styles.textContainer}>
-            <Text style={styles.stageText}>stage 2</Text>
+            <Text style={styles.stageText}>Stage 2</Text>
             <Text style={styles.timeText}>{timeLeft}</Text>
           </View>
           {isPauseButtonVisible ? (
@@ -211,7 +232,7 @@ export default function Stage2Screen() {
           </View>
         ) : null}
       </View>
-      <ChallengeModal currentStage={currentStage} setIsPaused={setIsPaused} />
+      {!isAnimating && <ChallengeModal currentStage={currentStage} setIsPaused={setIsPaused} />}
       <GameResultModal
         visible={isGameResultModalVisible}
         currentStage={currentStage}
@@ -265,6 +286,31 @@ const styles = StyleSheet.create({
     borderColor: "#49a246",
     backgroundColor: "rgba(218, 247, 217, 0.4)",
   },
+  textInfoContainer: {
+    justifyContent: "center",
+    alignItems: "center",
+    width: vw(90),
+    height: vh(7),
+    top: 130,
+    backgroundColor: "rgba(255, 255, 255, 0.7)",
+    borderRadius: 10,
+    zIndex: 1,
+  },
+  centered: {
+    width: vw(100),
+    position: "absolute",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  infoText: {
+    fontSize: 20,
+    textAlign: "center",
+    fontWeight: "bold",
+    color: "#0f0f0f",
+    textShadowColor: "#fff",
+    textShadowOffset: { width: 1, height: 1 },
+    textShadowRadius: 2,
+  },
   Images: {
     width: vw(10),
     height: vh(10),
@@ -284,5 +330,13 @@ const styles = StyleSheet.create({
     fontSize: 50,
     fontWeight: "bold",
     color: "#49a246",
+  },
+  loadingOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 10,
+    backgroundColor: "#fff",
+  },
+  specialText: {
+    color: "#ff7f00",
   },
 });

--- a/app/StageSelectScreen/StageSelectScreen.jsx
+++ b/app/StageSelectScreen/StageSelectScreen.jsx
@@ -41,8 +41,6 @@ function StageCardButton({
 
 export default function StageSelectScreen() {
   const [starCounts, setStarCounts] = useState({});
-  const [isLoading, setIsLoading] = useState(false);
-  const [selectedStage, setSelectedStage] = useState(null);
   const router = useRouter();
 
   useEffect(() => {
@@ -57,19 +55,8 @@ export default function StageSelectScreen() {
   }
 
   function handleStageCardButtonTouch(id) {
-    setSelectedStage(id);
-    setIsLoading(true);
+    router.replace(`/StageScreen/Stage${id}Screen`);
   }
-
-  useEffect(() => {
-    if (isLoading && selectedStage !== null) {
-      router.replace("/LoadingScreen/LoadingScreen");
-      setTimeout(() => {
-        setIsLoading(false);
-        router.replace(`/StageScreen/Stage${selectedStage}Screen`);
-      }, 2000);
-    }
-  }, [isLoading, selectedStage]);
 
   function handleMainButtonTouch() {
     router.replace("/MainScreen/MainScreen");

--- a/src/components/CameraController/CameraController.jsx
+++ b/src/components/CameraController/CameraController.jsx
@@ -7,64 +7,62 @@ export default function CameraController({ followTarget, isAnimating, setIsAnima
   const desiredPosition = useRef(new THREE.Vector3());
   const initialTargetPosition = useRef(new THREE.Vector3());
   const fixedLookAtPosition = useRef(new THREE.Vector3());
+  const fixedPosition = new THREE.Vector3(0, 1, 140);
 
   useEffect(() => {
-    if (followTarget.current) {
-      const checkTargetPosition = setInterval(() => {
-        if (followTarget.current) {
-          initialTargetPosition.current
-            .copy(followTarget.current.position)
-            .add(new THREE.Vector3(0, 45, 20));
-          fixedLookAtPosition.current.copy(followTarget.current.position);
-          const initialPosition = fixedLookAtPosition.current
-            .clone()
-            .add(new THREE.Vector3(0, 300, 100));
-          camera.position.copy(initialPosition);
-          camera.lookAt(fixedLookAtPosition.current);
-          setIsAnimating(true);
-          clearInterval(checkTargetPosition);
+    const checkTargetPosition = setInterval(() => {
+      if (followTarget.current) {
+        initialTargetPosition.current.copy(fixedPosition).add(new THREE.Vector3(0, 45, 35));
+        fixedLookAtPosition.current.copy(fixedPosition);
 
-          const animationDuration = 3000;
-          const pauseDuration = 1500;
-          const startTime = performance.now();
+        const initialPosition = fixedLookAtPosition.current
+          .clone()
+          .add(new THREE.Vector3(0, 300, 100));
+        camera.position.copy(initialPosition);
+        camera.lookAt(fixedLookAtPosition.current);
+        setIsAnimating(true);
+        clearInterval(checkTargetPosition);
 
-          const animate = (time) => {
-            const elapsedTime = time - startTime;
+        const animationDuration = 3000;
+        const pauseDuration = 1500;
+        const startTime = performance.now();
 
-            if (elapsedTime < pauseDuration) {
+        const animate = (time) => {
+          const elapsedTime = time - startTime;
+
+          if (elapsedTime < pauseDuration) {
+            requestAnimationFrame(animate);
+          } else {
+            const animationProgress = Math.min(
+              (elapsedTime - pauseDuration) / animationDuration,
+              1,
+            );
+
+            camera.position.lerpVectors(
+              initialPosition,
+              initialTargetPosition.current,
+              animationProgress,
+            );
+            camera.lookAt(fixedLookAtPosition.current);
+
+            if (animationProgress < 1) {
               requestAnimationFrame(animate);
             } else {
-              const animationProgress = Math.min(
-                (elapsedTime - pauseDuration) / animationDuration,
-                1,
-              );
-
-              camera.position.lerpVectors(
-                initialPosition,
-                initialTargetPosition.current,
-                animationProgress,
-              );
-              camera.lookAt(fixedLookAtPosition.current);
-
-              if (animationProgress < 1) {
-                requestAnimationFrame(animate);
-              } else {
-                setIsAnimating(false);
-              }
+              setIsAnimating(false);
             }
-          };
+          }
+        };
 
-          requestAnimationFrame(animate);
-        }
-      }, 100);
-    }
+        requestAnimationFrame(animate);
+      }
+    }, 100);
   }, [camera, followTarget]);
 
   useFrame(() => {
     if (!isAnimating && followTarget.current) {
       const ballPosition = followTarget.current.position;
-      const dynamicHeightOffset = Math.max(0, ballPosition.y + 50);
-      desiredPosition.current.set(ballPosition.x, dynamicHeightOffset - 15, ballPosition.z + 30);
+      const dynamicHeightOffset = Math.max(0, ballPosition.y + 70);
+      desiredPosition.current.set(ballPosition.x, dynamicHeightOffset - 25, ballPosition.z + 35);
 
       camera.position.lerp(desiredPosition.current, 0.1);
       camera.lookAt(ballPosition);

--- a/src/components/CameraController/CameraController.jsx
+++ b/src/components/CameraController/CameraController.jsx
@@ -1,19 +1,72 @@
-import { useFrame, useThree } from "@react-three/fiber";
+import { useFrame, useThree } from "@react-three/fiber/native";
+import { useRef, useEffect } from "react";
 import * as THREE from "three";
 
-export default function CameraController({ followTarget }) {
+export default function CameraController({ followTarget, isAnimating, setIsAnimating }) {
   const { camera } = useThree();
+  const desiredPosition = useRef(new THREE.Vector3());
+  const initialTargetPosition = useRef(new THREE.Vector3());
+  const fixedLookAtPosition = useRef(new THREE.Vector3());
+
+  useEffect(() => {
+    if (followTarget.current) {
+      const checkTargetPosition = setInterval(() => {
+        if (followTarget.current) {
+          initialTargetPosition.current
+            .copy(followTarget.current.position)
+            .add(new THREE.Vector3(0, 45, 20));
+          fixedLookAtPosition.current.copy(followTarget.current.position);
+          const initialPosition = fixedLookAtPosition.current
+            .clone()
+            .add(new THREE.Vector3(0, 300, 100));
+          camera.position.copy(initialPosition);
+          camera.lookAt(fixedLookAtPosition.current);
+          setIsAnimating(true);
+          clearInterval(checkTargetPosition);
+
+          const animationDuration = 3000;
+          const pauseDuration = 1500;
+          const startTime = performance.now();
+
+          const animate = (time) => {
+            const elapsedTime = time - startTime;
+
+            if (elapsedTime < pauseDuration) {
+              requestAnimationFrame(animate);
+            } else {
+              const animationProgress = Math.min(
+                (elapsedTime - pauseDuration) / animationDuration,
+                1,
+              );
+
+              camera.position.lerpVectors(
+                initialPosition,
+                initialTargetPosition.current,
+                animationProgress,
+              );
+              camera.lookAt(fixedLookAtPosition.current);
+
+              if (animationProgress < 1) {
+                requestAnimationFrame(animate);
+              } else {
+                setIsAnimating(false);
+              }
+            }
+          };
+
+          requestAnimationFrame(animate);
+        }
+      }, 100);
+    }
+  }, [camera, followTarget]);
 
   useFrame(() => {
-    if (followTarget.current) {
+    if (!isAnimating && followTarget.current) {
       const ballPosition = followTarget.current.position;
-      const desiredPosition = new THREE.Vector3(
-        ballPosition.x,
-        ballPosition.y + 15,
-        ballPosition.z + 30,
-      );
+      const dynamicHeightOffset = Math.max(0, ballPosition.y + 50);
+      desiredPosition.current.set(ballPosition.x, dynamicHeightOffset - 15, ballPosition.z + 30);
 
-      camera.position.lerp(desiredPosition, 0.1);
+      camera.position.lerp(desiredPosition.current, 0.1);
       camera.lookAt(ballPosition);
     }
   });

--- a/src/components/GameDescriptionModal/GameDescriptionModal.jsx
+++ b/src/components/GameDescriptionModal/GameDescriptionModal.jsx
@@ -186,7 +186,7 @@ const styles = StyleSheet.create({
   },
   rowWrapper: {
     width: "80%",
-    height: "40%",
+    height: Platform.OS === "ios" ? "46%" : "40%",
     flexDirection: "row",
     justifyContent: "center",
     alignItems: "center",

--- a/src/components/GameDescriptionModal/GameDescriptionModal.jsx
+++ b/src/components/GameDescriptionModal/GameDescriptionModal.jsx
@@ -108,7 +108,7 @@ export default function GameDescriptionModal({
   function descriptionText3() {
     switch (descriptionImages) {
       case 0:
-        return "튜토리얼을 통해 사용감을 익혀보세요!";
+        return "튜토리얼을 통해 조작감을 익혀보세요!";
       case 1:
         return null;
       case 2:
@@ -155,13 +155,11 @@ export default function GameDescriptionModal({
           <Text style={styles.descriptionText1}>{descriptionText1()}</Text>
           <Text style={styles.descriptionText2}>{descriptionText2()}</Text>
           <Text style={styles.descriptionText2}>{descriptionText3()}</Text>
-          <View>
-            <CustomButton
-              containerStyle={styles.closeButton}
-              buttonText="설명 닫기"
-              onPress={handleCloseButtonTouch}
-            />
-          </View>
+          <CustomButton
+            containerStyle={styles.closeButton}
+            buttonText="설명 닫기"
+            onPress={handleCloseButtonTouch}
+          />
         </View>
       </View>
     </Modal>
@@ -176,8 +174,9 @@ const styles = StyleSheet.create({
     backgroundColor: "rgba(0, 0, 0, 0.9)",
   },
   modalView: {
-    width: vw(85),
-    height: Platform.OS === "ios" ? vh(60) : vh(73),
+    width: Platform.OS === "ios" ? vw(85) : vw(88),
+    height: Platform.OS === "ios" ? vh(60) : vh(78),
+    padding: 8,
     alignItems: "center",
     borderWidth: 3,
     borderStyle: "solid",
@@ -187,15 +186,16 @@ const styles = StyleSheet.create({
   },
   rowWrapper: {
     width: "80%",
-    height: "46%",
+    height: "40%",
     flexDirection: "row",
     justifyContent: "center",
     alignItems: "center",
   },
   closeButton: {
+    position: "absolute",
     backgroundColor: "#DAF7D9",
+    top: "88%",
     width: vw(30),
-    marginHorizontal: 15,
     marginTop: vh(3),
     padding: 10,
   },


### PR DESCRIPTION
## Task Kanban
[로딩 구현 및 카메라 조정](https://www.notion.so/f305d7757009438b88a1f9354cc812ac?pvs=4)

## Description
**1. 로딩 구현**
- 스테이지 선택 화면에서 스테이지 버튼을 터치하면 해당 스테이지로 라우팅됩니다.
- 스테이지 진입 시, 3D scene에 대한 렌더링과 초기값 설정을 모두 마칠 때까지 로딩 컴포넌트가 보여집니다.
- 현재 로딩 속도가 몹시 빨라 setTimeout으로 로딩을 마친 후 0.5초 뒤에 로딩 컴포넌트가 사라지도록 구현했습니다.

**2. 카메라 애니메이션 구현**
- 로딩을 마친 뒤 카메라가 맵 전체를 비추고 공을 향해 서서히 다가갑니다.
- 카메라 애니메이션이 재생되는 동안에는 공의 조작이 불가능합니다.
- 카메라 애니메이션이 끝난 뒤 스테이지 1, 2에서는 도전 과제의 모달이 보여집니다. 튜토리얼에서는 게임 설명 모달이 보여집니다.
- 도전 과제 모달 혹은 게임 설명 모달을 종료시킨 뒤부터 공의 조작이 가능해집니다.

**3. 카메라 조정**
- 카메라 각도를 조정하였습니다.
- 공이 언덕을 오르면 카메라의 y축 좌표가 상승하게 구현했습니다. 언덕으로 인해 시야에 공이 가려지지 않게 했습니다.

## 특이사항
- 게임 설명 모달의 닫기 버튼 위치를 모달 하단으로 고정시켰습니다.
- 스테이지 진입 시 게임이 정지 상태, 혹은 카메라 애니메이션이 재생 중인 상태이면 (isPaused, isAnimating 상태가 true이면) 공의 위치가 설정값이 아닌 (0, 0, 0)인 상태로 유지되는 문제가 있었습니다.
- 공의 위치가 설정되기 전에 isPaused, isAnimating로 인하여 early return 되었기 때문이었습니다. 
- ball의 물리 관련 코드 순서를 일부 수정하여 해결했습니다. (공의 위치를 설정한 뒤에 상태를 확인하고 early return되게 했습니다)

## 스크린샷
<img src="https://github.com/RollingArt/rollingart-project/assets/160200515/1657913b-41e2-4afc-90e6-c03bd73e9e07" width="300">
<img src="https://github.com/RollingArt/rollingart-project/assets/160200515/3b6f8ac0-5e57-44c1-bf4c-147b55bdd4d0" width="300">

## PR 전 체크리스트
- [x] 최신 브랜치를 pull하였습니다.
- [x] 리뷰어를 설정했습니다.
- [x] base 브랜치를 확인하였습니다.
- [x] 브랜치명을 확인했습니다.
- [x] 팀원이 쉽게 이해할 수 있도록, 구현 사항에 대해 설명하고 참고 자료를 제공했습니다. 