### PR TITLE
Chore: 테스트 커버리지 설정 추가 및 커버리지 확인 가능하도록 명령어 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ yarn-error.*
 
 # typescript
 *.tsbuildinfo
+
+#test
+coverage/

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,23 @@ module.exports = {
   transformIgnorePatterns: [
     "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)",
   ],
+  collectCoverage: true,
+  collectCoverageFrom: [
+    "src/**/*.{js,jsx,ts,tsx}",
+    "!src/**/*.d.ts",
+    "!src/index.js",
+    "!src/reportWebVitals.js",
+    "!**/node_modules/**",
+    "!**/vendor/**",
+  ],
+  coverageReporters: ["text", "lcov", "clover"],
+  coverageDirectory: "<rootDir>/coverage",
+  testMatch: [
+    "<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}",
+    "<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}",
+  ],
+  moduleFileExtensions: ["js", "jsx", "ts", "tsx"],
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/$1",
+  },
 };

--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "lint": "eslint .",
-    "test": "jest --coverage",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@expo/metro-runtime": "~3.2.1",


### PR DESCRIPTION
## Description
테스트 커버리지 관련한 설정 및 명령어를 추가하였습니다. 
또한, 커버리지 확인으로 인해 생성된 파일을 내보내지 않도록 .gitignore 설정을 추가하였습니다.

- 테스트 관련 명령어
  - `npm test`: 일반 테스트 실행
  - `npm run test:coverage`: 커버리지 보고서를 생성하며 테스트 실행
  - `npm run test:watch`: 파일 변경을 감지하여 자동으로 테스트 실행

## PR 전 체크리스트

- [x] 최신 브랜치를 pull하였습니다.
- [x] 리뷰어를 설정했습니다.
- [x] base 브랜치를 확인하였습니다.
- [x] 브랜치명을 확인했습니다.
- [x] 팀원이 쉽게 이해할 수 있도록, 구현 사항에 대해 설명하고 참고 자료를 제공했습니다.
